### PR TITLE
US-551354: Move to using standard MashupAPI to create case

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
   "extends": "@pega/prettier-config",
-  "printWidth": 120,
+  "printWidth": 150,
   "singleQuote": true,
   "trailingComma": "none"
 }

--- a/packages/angular-sdk-components/src/app/_components/infra/root-container/root-container.component.html
+++ b/packages/angular-sdk-components/src/app/_components/infra/root-container/root-container.component.html
@@ -6,7 +6,11 @@
   <div [ngSwitch]="componentName$">
     <app-view *ngSwitchCase="'View'" [pConn$]="pConn$" [displayOnlyFA$]="displayOnlyFA$"></app-view>
     <!-- <app-reference *ngSwitchCase="'reference'" [pConn$]="pConn$" [displayOnlyFA$]="displayOnlyFA$"></app-reference> -->
-    <app-view-container *ngSwitchCase="'ViewContainer'" [pConn$]="pConn$" [displayOnlyFA$]="displayOnlyFA$"></app-view-container>
+    <app-view-container
+      *ngSwitchCase="'ViewContainer'"
+      [pConn$]="displayOnlyFA$ ? viewContainerPConn$ : pConn$"
+      [displayOnlyFA$]="displayOnlyFA$"
+    ></app-view-container>
     <app-hybrid-view-container *ngSwitchCase="'HybridViewContainer'" [pConn$]="pConn$" [displayOnlyFA$]="displayOnlyFA$"></app-hybrid-view-container>
     <app-modal-view-container
       *ngSwitchCase="'ModalViewContainer'"

--- a/packages/angular-sdk-components/src/app/_components/infra/root-container/root-container.component.ts
+++ b/packages/angular-sdk-components/src/app/_components/infra/root-container/root-container.component.ts
@@ -17,6 +17,8 @@ import { ViewComponent } from '../view/view.component';
  * is totally at your own risk.
  */
 
+const options = { context: 'app' };
+
 @Component({
   selector: 'app-root-container',
   templateUrl: './root-container.component.html',
@@ -53,20 +55,12 @@ export class RootContainerComponent implements OnInit {
 
   progressSpinnerSubscription: Subscription;
   spinnerTimer: any = null;
+  viewContainerPConn$: any = null;
 
-  constructor(
-    private angularPConnect: AngularPConnectService,
-    private psService: ProgressSpinnerService,
-    private ngZone: NgZone
-  ) {}
+  constructor(private angularPConnect: AngularPConnectService, private psService: ProgressSpinnerService, private ngZone: NgZone) {}
 
   ngOnInit(): void {
     let myContext = 'app';
-    if (this.isMashup$) {
-      myContext = 'root';
-    }
-
-    const options = { context: myContext };
 
     if (!this.PCore$) {
       this.PCore$ = window.PCore;
@@ -153,13 +147,7 @@ export class RootContainerComponent implements OnInit {
     const renderingModes = ['portal', 'view'];
     const noPortalMode = 'noPortal';
 
-    let myContext = 'app';
-    if (this.isMashup$) {
-      myContext = 'root';
-    }
-
-    const options = { context: myContext };
-    const { renderingMode, children, skeleton, httpMessages, routingInfo } = myProps;
+    const { renderingMode, children, skeleton, routingInfo } = myProps;
 
     if (routingInfo && renderingModes.includes(renderingMode)) {
       const { accessedOrder, items } = routingInfo;
@@ -205,7 +193,20 @@ export class RootContainerComponent implements OnInit {
         setTimeout(() => {
           this.ngZone.run(() => {
             let localPConn = arChildren[0].getPConnect();
+
             this.componentName$ = localPConn.getComponentName();
+            if (this.componentName$ === 'ViewContainer') {
+              const configProps = this.pConn$.getConfigProps();
+              const viewContConfig = {
+                meta: {
+                  type: 'ViewContainer',
+                  config: configProps
+                },
+                options
+              };
+
+              this.viewContainerPConn$ = this.PCore$.createPConnect(viewContConfig).getPConnect();
+            }
             this.bShowRoot$ = true;
           });
         });

--- a/packages/angular-sdk-components/src/app/_samples/full-portal/top-app-mashup/top-app-mashup.component.ts
+++ b/packages/angular-sdk-components/src/app/_samples/full-portal/top-app-mashup/top-app-mashup.component.ts
@@ -74,7 +74,7 @@ export class TopAppMashupComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.scservice.getServerConfig().then(() => {
+    this.scservice.readSdkConfig().then(() => {
       this.initialize();
     });
   }
@@ -121,9 +121,8 @@ export class TopAppMashupComponent implements OnInit {
       });
     });
 
-    const thePortal = this.scservice.getAppPortal();
+    const { appPortal: thePortal, excludePortals } = this.scservice.getSdkConfigServer();
     const defaultPortal = window.PCore?.getEnvironmentInfo?.().getDefaultPortal?.();
-    const excludePortals = this.scservice.getSdkConfigServer().excludePortals;
 
     // Note: myLoadPortal and myLoadDefaultPortal are set when bootstrapWithAuthHeader is invoked
     if (thePortal) {

--- a/packages/angular-sdk-components/src/app/_samples/mashup/main-screen/main-screen.component.html
+++ b/packages/angular-sdk-components/src/app/_samples/mashup/main-screen/main-screen.component.html
@@ -8,10 +8,10 @@
       <app-bundle-swatch [swatchConfig$]="thirdConfig$" (ShopNowButtonClick)="onShopNow($event)"></app-bundle-swatch>
     </div>
   </div>
-  <div *ngIf="showPega$">
+  <div [hidden]="!showPega$">
     <div class="mc-info">
       <div class="mc-info-pega">
-        <app-root-container [pConn$]="pConn$" [displayOnlyFA$]="true" [isMashup$]="true"></app-root-container>
+        <app-root-container [pConn$]="pConn$" [displayOnlyFA$]="true"></app-root-container>
         <div style="padding-left: 50px">* - required fields</div>
       </div>
       <div class="mc-info-banner">

--- a/packages/angular-sdk-components/src/app/_samples/mashup/mc-nav/mc-nav.component.html
+++ b/packages/angular-sdk-components/src/app/_samples/mashup/mc-nav/mc-nav.component.html
@@ -4,7 +4,7 @@
 
 <mat-toolbar color="primary" class="mc-toolbar">
   <mat-toolbar-row class="mc-toolbar-row">
-    MediaCo
+    {{ applicationLabel }}
     <mat-icon class="mc-icon">router</mat-icon>
 
     <span class="toolbar-spacer"> </span>

--- a/packages/angular-sdk-components/src/app/_samples/simple-portal/main-content/main-content.component.html
+++ b/packages/angular-sdk-components/src/app/_samples/simple-portal/main-content/main-content.component.html
@@ -4,5 +4,5 @@
 </div>
 
 <div *ngIf="sComponentName$ == 'RootContainer'">
-  <app-root-container [pConn$]="pConn$" [PCore$]="PCore$" [props$]="props$" [isMashup$]="true" [displayOnlyFA$]="false"></app-root-container>
+  <app-root-container [pConn$]="pConn$" [PCore$]="PCore$" [props$]="props$" [displayOnlyFA$]="false"></app-root-container>
 </div>

--- a/packages/angular-sdk-components/src/app/_samples/simple-portal/navigation/navigation.component.ts
+++ b/packages/angular-sdk-components/src/app/_samples/simple-portal/navigation/navigation.component.ts
@@ -59,7 +59,7 @@ export class NavigationComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.scservice.getServerConfig().then(() => {
+    this.scservice.readSdkConfig().then(() => {
       this.initialize();
     });
   }
@@ -68,10 +68,7 @@ export class NavigationComponent implements OnInit {
     this.progressSpinnerSubscription.unsubscribe();
     this.resetPConnectSubscription.unsubscribe();
 
-    this.PCore$.getPubSubUtils().unsubscribe(
-      this.PCore$.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL,
-      'cancelAssignment'
-    );
+    this.PCore$.getPubSubUtils().unsubscribe(this.PCore$.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL, 'cancelAssignment');
 
     this.PCore$.getPubSubUtils().unsubscribe('assignmentFinished', 'assignmentFinished');
 
@@ -193,10 +190,7 @@ export class NavigationComponent implements OnInit {
     //
     // so don't have multiple subscriptions, unsubscribe first
     //
-    this.PCore$.getPubSubUtils().unsubscribe(
-      this.PCore$.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL,
-      'cancelAssignment'
-    );
+    this.PCore$.getPubSubUtils().unsubscribe(this.PCore$.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL, 'cancelAssignment');
 
     this.PCore$.getPubSubUtils().unsubscribe('assignmentFinished', 'assignmentFinished');
 

--- a/packages/angular-sdk-components/src/app/_services/auth.service.ts
+++ b/packages/angular-sdk-components/src/app/_services/auth.service.ts
@@ -7,7 +7,7 @@ import { ServerConfigService } from './server-config.service';
 declare const PCore;
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class AuthService {
   authMgr: any;
@@ -20,7 +20,7 @@ export class AuthService {
   gbCustomAuth: boolean = false;
 
   constructor(private scService: ServerConfigService, private oarservice: OAuthResponseService) {
-    this.scService.getServerConfig().then(() => {});
+    this.scService.readSdkConfig();
   }
 
   /*
@@ -36,7 +36,7 @@ export class AuthService {
     }
   };
 
-  setNoMainRedirect = (bNoInitialRedirect) => {
+  setNoInitialRedirect = (bNoInitialRedirect) => {
     if (bNoInitialRedirect) {
       this.forcePopupForReauths(true);
       sessionStorage.setItem('asdk_noRedirect', '1');
@@ -76,7 +76,7 @@ export class AuthService {
   };
 
   updateLoginStatus = () => {
-    const sAuthHdr = this.getAuthHeader();
+    const sAuthHdr = this.sdkGetAuthHeader();
     this.bLoggedIn = sAuthHdr && sAuthHdr.length > 0;
   };
 
@@ -85,24 +85,21 @@ export class AuthService {
    * @param {Object} authConfig
    * @param {Object} tokenInfo
    */
-  constellationInit = (authConfig: any, tokenInfo: any) => {
-    /*
-    // Safety check (should no longer be necessary)
-    const bLoginRedirectCodePage = window.location.href.indexOf("?code") !== -1;
-    if( bLoginRedirectCodePage ) {
-      return;
-    }
-    */
-
+  constellationInit = (authConfig: any, tokenInfo: any, authTokenUpdated, fnReauth) => {
     const constellationBootConfig: any = {};
     const sdkConfigServer = this.scService.getSdkConfigServer();
 
     // Set up constellationConfig with data that bootstrapWithAuthHeader expects
-    // constellationConfig.appAlias = "";
     constellationBootConfig.customRendering = true;
     constellationBootConfig.restServerUrl = sdkConfigServer.infinityRestServerUrl;
-    // Removed /constellation/ from sdkContentServerUrl
+    // NOTE: Needs a trailing slash! So add one if not provided
+    if (!sdkConfigServer.sdkContentServerUrl.endsWith('/')) {
+      sdkConfigServer.sdkContentServerUrl = `${sdkConfigServer.sdkContentServerUrl}/`;
+    }
     constellationBootConfig.staticContentServerUrl = `${sdkConfigServer.sdkContentServerUrl}constellation/`;
+    if (!constellationBootConfig.staticContentServerUrl.endsWith('/')) {
+      constellationBootConfig.staticContentServerUrl = `${constellationBootConfig.staticContentServerUrl}/`;
+    }
     // If appAlias specified, use it
     if (sdkConfigServer.appAlias) {
       constellationBootConfig.appAlias = sdkConfigServer.appAlias;
@@ -122,13 +119,13 @@ export class AuthService {
         endPoints: {
           authorize: authConfig.authorizeUri,
           token: authConfig.tokenUri,
-          revoke: authConfig.revokeUri,
+          revoke: authConfig.revokeUri
         },
         // TODO: setup callback so we can update own storage
-        onTokenRetrieval: this.updateTokens.bind(this),
+        onTokenRetrieval: this.updateTokens.bind(this)
       };
     } else {
-      constellationBootConfig.authorizationHeader = this.getAuthHeader();
+      constellationBootConfig.authorizationHeader = this.sdkGetAuthHeader();
     }
 
     // Turn off dynamic load components (should be able to do it here instead of after load?)
@@ -147,8 +144,6 @@ export class AuthService {
         // NOTE: once this callback is done, we lose the ability to access loadMashup.
         //  So, create a reference to it
         window.myLoadMashup = bootstrapShell.loadMashup;
-
-        // Save a reference to loadPortal,loadDefaultPortal too!
         window.myLoadPortal = bootstrapShell.loadPortal;
         window.myLoadDefaultPortal = bootstrapShell.loadDefaultPortal;
 
@@ -176,19 +171,9 @@ export class AuthService {
           })
           .catch((e) => {
             // Assume error caught is because token is not valid and attempt a full reauth
-
             console.error(`Constellation JS Engine bootstrap failed. ${e}`);
             this.gbC11NBootstrapInProgress = false;
             this.fullReauth();
-            /*
-        if( this.isLoginInProgress() ) {
-          // This flag should be reset prior to invoking constellationInit
-          console.log(`Login in progress just prior to fullReauth....so abandoning full reauth.`);
-        } else {
-  //        this.fullReauth();
-        console.log(`Login not in progress so would have been invoking full reAuth. loginRedirectCodePage: ${bLoginRedirectCodePage}`);
-        }
-        */
           });
       })
       .catch((e) => {
@@ -201,12 +186,17 @@ export class AuthService {
     if (!token) {
       // This is used on page reload to load the token from sessionStorage and carry on
       token = this.getCurrentTokens();
+      if (!token) {
+        return;
+      }
     }
 
+    sessionStorage.setItem('asdk_AH', `${token.token_type} ${token.access_token}`);
     this.updateLoginStatus();
 
     // bLoggedIn is getting updated in updateLoginStatus
     this.bLoggedIn = true;
+    sessionStorage.removeItem('asdk_loggingIn');
     this.forcePopupForReauths(true);
 
     const sSI = sessionStorage.getItem('asdk_CI');
@@ -230,7 +220,7 @@ export class AuthService {
     */
     // Code that sets up use of Constellation once it's been loaded and ready
     if (!window.PCore && bLoadC11N) {
-      this.constellationInit(authConfig, token);
+      this.constellationInit(authConfig, token, this.authTokenUpdated, this.authFullReauth.bind(this));
     }
   };
 
@@ -252,7 +242,7 @@ export class AuthService {
     }
   };
 
-  updateRedirectUri = (sRedirectUri) => {
+  updateRedirectUri = (aMgr, sRedirectUri) => {
     const sSI = sessionStorage.getItem('asdk_CI');
     let authConfig = null;
     if (sSI !== null) {
@@ -264,7 +254,7 @@ export class AuthService {
     }
     authConfig.redirectUri = sRedirectUri;
     sessionStorage.setItem('asdk_CI', JSON.stringify(authConfig));
-    this.authMgr.reloadConfig();
+    aMgr.reloadConfig();
   };
 
   authRedirectCallback = (href, fnLoggedInCB = null) => {
@@ -273,14 +263,16 @@ export class AuthService {
     const urlParams = new URLSearchParams(aHrefParts.length > 1 ? `?${aHrefParts[1]}` : '');
     const code = urlParams.get('code');
 
-    this.authMgr.getToken(code).then((token) => {
-      if (token && token.access_token) {
-        this.processTokenOnLogin(token, false);
-        // this.getUserInfo();
-        if (fnLoggedInCB) {
-          fnLoggedInCB(token);
+    this.getAuthMgr(false).then((aMgr) => {
+      aMgr.getToken(code).then((token) => {
+        if (token && token.access_token) {
+          this.processTokenOnLogin(token, false);
+          // this.getUserInfo();
+          if (fnLoggedInCB) {
+            fnLoggedInCB(token.access_token);
+          }
         }
-      }
+      });
     });
   };
 
@@ -309,14 +301,18 @@ export class AuthService {
     return sessionStorage.getItem('asdk_noRedirect') === '1';
   };
 
-  initAuthMgr = (bInit) => {
-    const sdkConfigAuth = this.scService.getSdkConfigAuth();
+  initOAuth = async (bInit) => {
+    const sdkConfigAuth = await this.scService.getSdkConfigAuth();
     const sdkConfigServer = this.scService.getSdkConfigServer();
-    const pegaUrl = sdkConfigServer.infinityRestServerUrl;
-    const currPath = location.pathname;
+    let pegaUrl = sdkConfigServer.infinityRestServerUrl;
+    const bNoInitialRedirect = this.authNoRedirect();
 
     // Construct default OAuth endpoints (if not explicitly specified)
     if (pegaUrl) {
+      // Cope with trailing slash being present
+      if (!pegaUrl.endsWith('/')) {
+        pegaUrl += '/';
+      }
       if (!sdkConfigAuth.authorize) {
         sdkConfigAuth.authorize = `${pegaUrl}PRRestService/oauth2/v1/authorize`;
       }
@@ -345,18 +341,18 @@ export class AuthService {
     sNoMainRedirectUri = nLastPathSep !== -1 ? `${sNoMainRedirectUri.substring(0, nLastPathSep + 1)}auth.html` : `${sNoMainRedirectUri}/auth.html`;
 
     const authConfig: any = {
-      clientId: this.bNoInitialRedirect ? sdkConfigAuth.mashupClientId : sdkConfigAuth.portalClientId,
+      clientId: bNoInitialRedirect ? sdkConfigAuth.mashupClientId : sdkConfigAuth.portalClientId,
       authorizeUri: sdkConfigAuth.authorize,
       tokenUri: sdkConfigAuth.token,
       revokeUri: sdkConfigAuth.revoke,
       userinfoUri: sdkConfigAuth.userinfo,
       redirectUri:
-        this.bNoInitialRedirect || this.bUsePopupForRestOfSession || endpoints.loginExperience === loginBoxType.Popup
+        bNoInitialRedirect || this.bUsePopupForRestOfSession || endpoints.loginExperience === loginBoxType.Popup
           ? sNoMainRedirectUri
           : sdkConfigAuth.redirectUri,
       authService: sdkConfigAuth.authService,
       appAlias: sdkConfigServer.appAlias || '',
-      useLocking: true,
+      useLocking: true
     };
     // If no clientId is specified assume not OAuth but custom auth
     if (!authConfig.clientId) {
@@ -366,7 +362,7 @@ export class AuthService {
     if ('silentTimeout' in sdkConfigAuth) {
       authConfig.silentTimeout = sdkConfigAuth.silentTimeout;
     }
-    if (this.bNoInitialRedirect) {
+    if (bNoInitialRedirect && sdkConfigAuth.mashupUserIdentifier && sdkConfigAuth.mashupPassword) {
       authConfig.userIdentifier = sdkConfigAuth.mashupUserIdentifier;
       authConfig.password = sdkConfigAuth.mashupPassword;
     }
@@ -384,6 +380,7 @@ export class AuthService {
         const oSI = JSON.parse(sSI);
         if (
           oSI.authorizeUri !== authConfig.authorizeUri ||
+          oSI.appAlias !== authConfig.appAlias ||
           oSI.clientId !== authConfig.clientId ||
           oSI.userIdentifier !== authConfig.userIdentifier ||
           oSI.password !== authConfig.password
@@ -402,14 +399,26 @@ export class AuthService {
     this.authMgr = new PegaAuth('asdk_CI');
   };
 
-  getAuthMgr = (bInit) => {
-    if (!this.authMgr) {
-      this.initAuthMgr(bInit);
-    }
-    return this.authMgr;
+  getAuthMgr = (bInit): Promise<any> => {
+    return new Promise((resolve) => {
+      let idNextCheck = null;
+      const fnCheckForAuthMgr = () => {
+        if (PegaAuth && !this.authMgr) {
+          this.initOAuth(bInit);
+        }
+        if (this.authMgr) {
+          if (idNextCheck) {
+            clearInterval(idNextCheck);
+          }
+          return resolve(this.authMgr);
+        }
+      };
+      fnCheckForAuthMgr();
+      idNextCheck = setInterval(fnCheckForAuthMgr, 10);
+    });
   };
 
-  getAuthHeader = () => {
+  sdkGetAuthHeader = () => {
     return sessionStorage.getItem('asdk_AH');
   };
 
@@ -452,54 +461,52 @@ export class AuthService {
         // do nothing
       }
     }
-    const aMgr = this.getAuthMgr(false);
-    const tokenInfo = this.getCurrentTokens();
-    return aMgr.getUserinfo(tokenInfo.access_token).then((data) => {
-      userInfo = data;
-      if (userInfo) {
-        sessionStorage.setItem('asdk_UI', JSON.stringify(userInfo));
-      } else {
-        sessionStorage.removeItem('asdk_UI');
-      }
-      return Promise.resolve(userInfo);
+    this.getAuthMgr(false).then((aMgr) => {
+      const tokenInfo = this.getCurrentTokens();
+      return aMgr.getUserinfo(tokenInfo.access_token).then((data) => {
+        userInfo = data;
+        if (userInfo) {
+          sessionStorage.setItem('asdk_UI', JSON.stringify(userInfo));
+        } else {
+          sessionStorage.removeItem('asdk_UI');
+        }
+        return Promise.resolve(userInfo);
+      });
     });
   };
 
   login = (bFullReauth: boolean = false) => {
-    this.scService.getServerConfig().then((sdkConfig) => {
-      let sRedirectUri = sdkConfig.authConfig.redirectUri;
-      // Needed so a redirect to login screen and back will know we are still in process of logging in
-      sessionStorage.setItem('asdk_loggingIn', `${Date.now()}`);
-      //console.log("loggingIn: setting time");
+    if (this.gbCustomAuth) return;
 
-      const aMgr = this.getAuthMgr(!bFullReauth);
-      // aMgr will always be same as this.authMgr
+    this.getAuthMgr(bFullReauth).then(async (aMgr) => {
       const bMainRedirect = !this.authNoRedirect();
+      const sdkConfigAuth = await this.scService.getSdkConfigAuth();
+      let sRedirectUri = sdkConfigAuth.redirectUri;
 
+      // If initial main redirect is OK, redirect to main page, otherwise will authorize in a popup window
       if (bMainRedirect && !bFullReauth) {
         // update redirect uri to be the root
-        this.updateRedirectUri(sRedirectUri);
-        this.authMgr.loginRedirect();
+        this.updateRedirectUri(aMgr, sRedirectUri);
+        aMgr.loginRedirect();
         // Don't have token til after the redirect
         return Promise.resolve(undefined);
       } else {
         // Construct path to redirect uri
         const nLastPathSep = sRedirectUri.lastIndexOf('/');
         sRedirectUri = nLastPathSep !== -1 ? `${sRedirectUri.substring(0, nLastPathSep + 1)}auth.html` : `${sRedirectUri}/auth.html`;
-        this.updateRedirectUri(sRedirectUri);
+        // Set redirectUri to static auth.html
+        this.updateRedirectUri(aMgr, sRedirectUri);
         return new Promise((resolve, reject) => {
-          this.authMgr
+          aMgr
             .login()
             .then((token) => {
-              this.processTokenOnLogin(token, true);
-              // this.getUserInfo();
+              this.processTokenOnLogin(token);
+              // getUserInfo();
               resolve(token.access_token);
             })
             .catch((e) => {
               sessionStorage.removeItem('asdk_loggingIn');
-              //console.log("login(): clearing loggingIn SS")
-
-              console.error(`Error caught during login: ${e}`);
+              console.log(e);
               reject(e);
             });
         });
@@ -522,11 +529,11 @@ export class AuthService {
       this.clearAuthMgr();
       sessionStorage.setItem('asdk_appName', appName);
     }
-    this.setNoMainRedirect(noMainRedirect);
+    this.setNoInitialRedirect(noMainRedirect);
     // If custom auth no need to do any OAuth logic
     if (this.gbCustomAuth) {
       if (!window.PCore) {
-        this.constellationInit(null, null);
+        this.constellationInit(null, null, null, this.authCustomReauth.bind(this));
       }
       return;
     }
@@ -535,24 +542,24 @@ export class AuthService {
     // eslint-disable-next-line @typescript-eslint/prefer-includes
     if (window.location.href.indexOf('?code') !== -1) {
       // initialize authMgr
-      this.initAuthMgr(false);
-      sessionStorage.removeItem('asdk_loggingIn');
-      //console.log("loginIfNecessary: clearing loggingIn");
-      this.authRedirectCallback(window.location.href, () => {
-        window.location.href = window.location.pathname;
+      this.initOAuth(false);
+      return this.getAuthMgr(false).then(() => {
+        this.authRedirectCallback(window.location.href, () => {
+          window.location.href = window.location.pathname;
+        });
       });
-      return;
     }
     // If not login redirect with auth code
     if (!deferLogin && (!this.isLoginInProgress() || this.isLoginExpired())) {
-      const aMgr = this.getAuthMgr(false);
-      this.updateLoginStatus();
-      if (this.bLoggedIn) {
-        this.fireTokenAvailable(this.getCurrentTokens());
-        // this.getUserInfo();
-      } else {
-        return this.login();
-      }
+      this.getAuthMgr(false).then(() => {
+        this.updateLoginStatus();
+        if (this.bLoggedIn) {
+          this.fireTokenAvailable(this.getCurrentTokens());
+          // this.getUserInfo();
+        } else {
+          return this.login();
+        }
+      });
     }
   };
 
@@ -571,6 +578,11 @@ export class AuthService {
     }
   };
 
+  // Passive update where just session storage is updated so can be used on a window refresh
+  authTokenUpdated = (tokenInfo) => {
+    sessionStorage.setItem('rsdk_TI', JSON.stringify(tokenInfo));
+  };
+
   logout = () => {
     return new Promise<void>((resolve) => {
       const fnClearAndResolve = () => {
@@ -582,7 +594,7 @@ export class AuthService {
         resolve();
       };
       if (this.gbCustomAuth) {
-        sessionStorage.removeItem('rsdk_AH');
+        sessionStorage.removeItem('asdk_AH');
         fnClearAndResolve();
         return;
       }
@@ -611,5 +623,26 @@ export class AuthService {
         fnClearAndResolve();
       }
     });
+  };
+
+  // Callback routine for custom event to ask for updated tokens
+  authUpdateTokens = (token) => {
+    this.processTokenOnLogin(token);
+  };
+
+  // Initiate a full OAuth re-authorization (any refresh token has also expired).
+  authFullReauth = () => {
+    const bHandleHere = true; // Other alternative is to raise an event and have someone else handle it
+
+    if (bHandleHere) {
+      // Don't want to do a full clear of authMgr as will loose sessionIndex.  Rather just clear the tokens
+      this.clearAuthMgr(true);
+      this.login(true);
+    } else {
+      // Fire the SdkFullReauth event to indicate a new token is needed (PCore.getAuthUtils.setTokens method
+      //  should be used to communicate the new token to Constellation JS Engine.
+      const event = new CustomEvent('SdkFullReauth', { detail: this.authUpdateTokens });
+      document.dispatchEvent(event);
+    }
   };
 }

--- a/sdk-config.json
+++ b/sdk-config.json
@@ -4,19 +4,20 @@
     "authConfig_comment": "Optional Full paths to Infinity server OAuth endpoints (Only needed if using custom OAuth service)",
     "authConfig_comment2": "Optional attributes are: authorize, token, revoke, authService, silentTimeout, iframeLoginUI",
     "authService": "pega",
-        
+
     "mashupClient_comment": "Client ID and Client secret from the OAuth 2.0 Client Registration record used for mashup use case",
     "mashupClient_comment2": "See SDK Guide for instructions on how to generate and obtain the proper values for the following entries",
     "mashupClientId": "69184022781147469983",
     "mashupUserIdentifier": "customer@mediaco",
+    "mashupClient_comment3": "Note: mashupPassword requires Base64 encoding",
     "mashupPassword": "",
-    
+
     "portalClientId_comment": "Client ID from the OAuth 2.0 Client Registration record used for portal use case",
     "portalClientId": "69184022781147469983"
   },
   "serverConfig": {
     "comment_serverConfig": "serverConfig is the block for SDK Content Server config entries",
-    
+
     "infinityRestServerUrl_comment": "Full path to Infinity REST server",
     "infinityRestServerUrl": "https://localhost:1080/prweb",
 
@@ -25,11 +26,14 @@
 
     "sdkContentServerUrl_comment": "If specified, the given URL will be used. If left blank, window.location.origin will be used.",
     "sdkContentServerUrl": "",
-    
+
     "appPortal_comment": "If specified, the given appPortal will be loaded. If left blank, the operator's default Portal is used. Ignored for Mashup",
     "appPortal": "",
 
+    "appMashupCaseType_comment": "If specified, uses this case type for mashup.  Otherwise, uses the first case type found for the app",
+    "appMashupCaseType": "",
+
     "excludePortals_comment": "Array of specific portals to avoid attempting to load with SDK",
-    "excludePortals" : ["pxExpress", "Developer", "pxPredictionStudio", "pxAdminStudio", "pyCaseWorker", "pyCaseManager7"]
+    "excludePortals": ["pxExpress", "Developer", "pxPredictionStudio", "pxAdminStudio", "pyCaseWorker", "pyCaseManager7"]
   }
 }


### PR DESCRIPTION
Move to use standard MashupAPI to create a case and reduce the need to add specific case type class names into code by adding a new config setting and introspecting casetypes for the current application.