### PR TITLE
Fix TimeOnly tests failing for 12 hrs

### DIFF
--- a/packages/angular-sdk-components/tests/e2e/DigV2/FormFields/Time.spec.js
+++ b/packages/angular-sdk-components/tests/e2e/DigV2/FormFields/Time.spec.js
@@ -51,7 +51,8 @@ test.describe('E2E test', () => {
     /** Required tests */
     const requiredTime = page.locator('input[id="mat-input-2"]');
     const date = new Date();
-    const time = `${date.getHours() % 12}${date.getMinutes()}AM`;
+    // Converting hours from 24 to 12 format, including the special case of "12"
+    const time = `${(date.getHours() % 12) || 12}${date.getMinutes()}AM`;
     requiredTime.type(time);
     attributes = await common.getAttributes(requiredTime);
     await expect(attributes.includes('required')).toBeTruthy();


### PR DESCRIPTION
* Fixed the Time test as it was getting failed in a specific case when time is "12:xx" and this is happening because we haven't handled this edge case in the Playwright test.
* Please refer BUG-831173 for more details.