### PR TITLE
Phone component misaligned dropdown fix

### DIFF
--- a/projects/angular-test-app/src/styles.scss
+++ b/projects/angular-test-app/src/styles.scss
@@ -84,3 +84,7 @@ a.mat-mdc-menu-item > mat-icon {
 .mat-mdc-form-field {
   margin: 8px 0;
 }
+
+.ngx-mat-tel-input-container button {
+  margin-top: auto;
+}


### PR DESCRIPTION
Country code dropdown in phone component is not aligned with phone input and country code overlapping with label