### PR TITLE
Fix Multi Select issues in table

### DIFF
--- a/packages/angular-sdk-components/src/lib/_components/template/list-view/list-view.component.html
+++ b/packages/angular-sdk-components/src/lib/_components/template/list-view/list-view.component.html
@@ -156,7 +156,7 @@
             <ng-container *ngIf="multiSelectionMode" matColumnDef="select">
               <th mat-header-cell *matHeaderCellDef></th>
               <td mat-cell *matCellDef="let row">
-                <mat-checkbox [value]="row[rowID]" (change)="onCheckboxClick(row, $event)"></mat-checkbox>
+                <mat-checkbox [value]="row[rowID]" [checked]="isChecked(row)" (change)="onCheckboxClick(row, $event)"></mat-checkbox>
               </td>
             </ng-container>
             <ng-container *ngFor="let dCol of fields$" [matColumnDef]="dCol.config.name">

--- a/packages/angular-sdk-components/src/lib/_components/template/list-view/list-view.component.ts
+++ b/packages/angular-sdk-components/src/lib/_components/template/list-view/list-view.component.ts
@@ -40,6 +40,8 @@ interface ListViewProps {
   presets?: any;
   reorderFields: string | boolean;
   grouping: string | boolean;
+  value: any;
+  readonlyContextList: any;
 }
 
 export class Group {
@@ -503,6 +505,13 @@ export class ListViewComponent implements OnInit, OnDestroy {
     if (this.repeatList$.paginator) {
       this.repeatList$.paginator.firstPage();
     }
+  }
+
+  isChecked(rowIn): any {
+    const initialVal = false;
+    return this.configProps$?.readonlyContextList?.reduce((acc, currRow) => {
+      return acc || rowIn[this.rowID] === currRow[this.rowID];
+    }, initialVal);
   }
 
   fieldOnChange(row) {


### PR DESCRIPTION
* Always the last record is getting selected.
* The slections aren't reflected in the UI, and that's allowing duplicate records selections also.
* Please refer BUG-879549 for more details.