### PR TITLE
Updated simple-table-manual, dropdown and fieldvaluelist components for US-691679

### DIFF
--- a/packages/angular-sdk-components/src/lib/_components/field/dropdown/dropdown.component.ts
+++ b/packages/angular-sdk-components/src/lib/_components/field/dropdown/dropdown.component.ts
@@ -134,6 +134,18 @@ export class DropdownComponent implements OnInit, OnDestroy {
     }
   }
 
+  set options(options: IOption[]) {
+    this.options$ = options;
+    if (this.displayMode$) {
+      this.value$ = this.options$?.find(option => option.key === this.value$)?.value || this.value$;
+      this.localizedValue = this.pConn$.getLocalizedValue(
+        this.value$ === 'Select...' ? '' : this.value$,
+        this.localePath,
+        this.pConn$.getLocaleRuleNameFromKeys(this.localeClass, this.localeContext, this.localeName)
+      );
+    }
+  }
+
   ngOnDestroy(): void {
     if (this.formGroup$) {
       this.formGroup$.removeControl(this.controlName$);
@@ -215,7 +227,7 @@ export class DropdownComponent implements OnInit, OnDestroy {
     if (this.theDatasource) {
       const optionsList = [...this.utils.getOptionList(this.configProps$, this.pConn$.getDataObject())];
       optionsList?.unshift({ key: 'Select', value: this.pConn$.getLocalizedValue('Select...', '', '') });
-      this.options$ = optionsList;
+      this.options = optionsList;
     }
 
     this.actionsApi = this.pConn$.getActionsApi();
@@ -281,7 +293,7 @@ export class DropdownComponent implements OnInit, OnDestroy {
     }
 
     columns = preProcessColumns(columns) || [];
-    if (!this.displayMode$ && listType !== 'associated' && typeof datasource === 'string') {
+    if (listType !== 'associated' && typeof datasource === 'string') {
       this.getData(datasource, parameters, columns, context, listType);
     }
   }
@@ -312,7 +324,7 @@ export class DropdownComponent implements OnInit, OnDestroy {
             optionsData.push(obj);
           });
           optionsData?.unshift({ key: 'Select', value: this.pConn$.getLocalizedValue('Select...', '', '') });
-          this.options$ = optionsData;
+          this.options = optionsData;
         });
       });
   }

--- a/packages/angular-sdk-components/src/lib/_components/template/field-value-list/field-value-list.component.html
+++ b/packages/angular-sdk-components/src/lib/_components/template/field-value-list/field-value-list.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="displayMode$ === 'DISPLAY_ONLY'; else STACKED_LARGE_VAL" class="psdk-container-labels-left">
-  <div class="psdk-grid-label">{{ label$ }}</div>
+<div *ngIf="displayMode$ === 'DISPLAY_ONLY'; else STACKED_LARGE_VAL" class="${label$ ? 'psdk-container-labels-left' : 'psdk-container-nolabels'}">
+  <div *ngIf="label$" class="psdk-grid-label">{{ label$ }}</div>
   <div class="psdk-val-labels-left">
     <ng-container *ngTemplateOutlet="valueTemplate"></ng-container>
   </div>

--- a/packages/angular-sdk-components/src/lib/_components/template/field-value-list/field-value-list.component.scss
+++ b/packages/angular-sdk-components/src/lib/_components/template/field-value-list/field-value-list.component.scss
@@ -6,6 +6,10 @@
   align-items: start;
   padding-block: 8px;
 }
+.psdk-container-nolabels {
+  align-items: start;
+  padding-block: 8px;
+}
 .psdk-value {
   margin: 8px 0px;
 }

--- a/packages/angular-sdk-components/src/lib/_components/template/simple-table-manual/helpers.ts
+++ b/packages/angular-sdk-components/src/lib/_components/template/simple-table-manual/helpers.ts
@@ -189,7 +189,7 @@ export const createMetaForTable = (fields, renderMode) => {
 };
 
 export const filterDataByDate = (item, filterObj) => {
-  let bKeep;
+  let bKeep = true;
   let value = item[filterObj.ref] != null || item[filterObj.ref] != '' ? getSeconds(item[filterObj.ref]) : null;
   let filterValue = filterObj.containsFilterValue != null && filterObj.containsFilterValue != '' ? getSeconds(filterObj.containsFilterValue) : null;
 
@@ -237,7 +237,7 @@ export const filterDataByDate = (item, filterObj) => {
 };
 
 export const filterDataByCommonFields = (item, filterObj) => {
-  let bKeep;
+  let bKeep = true;
   const value = item[filterObj.ref].toLowerCase();
   const filterValue = filterObj.containsFilterValue.toLowerCase();
 

--- a/packages/angular-sdk-components/src/lib/_components/template/simple-table-manual/simple-table-manual.component.html
+++ b/packages/angular-sdk-components/src/lib/_components/template/simple-table-manual/simple-table-manual.component.html
@@ -3,8 +3,8 @@
     <h3 *ngIf="label" className="label" style="font-weight: bold">
       {{ label }} <span class="results-count">{{ getResultsText() }}</span>
     </h3>
-    <table *ngIf="readOnlyMode || allowEditingInModal" mat-table [dataSource]="rowData" class="mat-elevation-z8" id="readonly-table" matSort>
-      <ng-container *ngFor="let dCol of processedFields" [matColumnDef]="dCol.config.name">
+    <table *ngIf="readOnlyMode || allowEditingInModal" mat-table [dataSource]="elementsData" class="mat-elevation-z8" id="readonly-table" matSort>
+      <ng-container *ngFor="let dCol of processedFields; let i = index" [matColumnDef]="dCol.config.name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header (click)="_headerSortClick($event, dCol)" arrowPosition="before">
           <div>{{ dCol.config.label }}</div>
           <div class="psdk-mat-header-filter">
@@ -27,7 +27,16 @@
             </mat-menu>
           </div>
         </th>
-        <td mat-cell *matCellDef="let element">{{ element[dCol.config.name] || '---' }}</td>
+        <td mat-cell *matCellDef="let element">
+          <component-mapper
+            [name]="element[i].getPConnect().getComponentName()"
+            [props]="{
+              pConn$: element[i].getPConnect(),
+              formGroup$: formGroup$
+            }"
+            errorMsg="Table wants component not yet available: {{ element[i].getPConnect().getComponentName() }}"
+          ></component-mapper>
+        </td>
       </ng-container>
       <ng-container matColumnDef="DeleteIcon">
         <div *ngIf="allowEditingInModal">
@@ -47,6 +56,9 @@
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr class="mat-row psdk-no-records" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="displayedColumns.length">No Records Found.</td>
+      </tr>
     </table>
     <table *ngIf="editableMode && !allowEditingInModal" mat-table [dataSource]="elementsData" class="mat-elevation-z8" id="editable-table">
       <ng-container *ngFor="let dCol of fieldDefs; let i = index">
@@ -74,9 +86,10 @@
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr class="mat-row psdk-no-records" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="displayedColumns.length">No Records Found.</td>
+      </tr>
     </table>
-    <div class="psdk-no-records" id="no-records" *ngIf="editableMode && referenceList?.length === 0">No Records Found.</div>
-    <div class="psdk-no-records" id="no-records" *ngIf="readOnlyMode && rowData?.data?.length === 0">No Records Found.</div>
   </div>
   <button *ngIf="showAddRowButton" mat-button color="primary" style="font-size: 16px" (click)="addRecord()">+ Add</button>
 </ng-container>

--- a/packages/angular-sdk-components/src/lib/_components/template/simple-table-manual/simple-table-manual.component.scss
+++ b/packages/angular-sdk-components/src/lib/_components/template/simple-table-manual/simple-table-manual.component.scss
@@ -24,6 +24,12 @@ td.mat-mdc-cell,
 td.mat-mdc-footer-cell {
   border-right: 1px solid var(--app-neutral-light-color);
   padding: 8px !important;
+  min-width: 10rem;
+}
+
+::ng-deep th.mat-mdc-header-cell:last-child,
+td.mat-mdc-cell:last-child {
+  min-width: 2rem;
 }
 
 ::ng-deep .mat-mdc-button {
@@ -160,9 +166,7 @@ tr.mat-mdc-header-row {
 
 .psdk-no-records {
   height: 56px;
-  justify-content: center;
-  display: flex;
-  align-items: center;
+  text-align: center;
   border: 1px solid var(--app-neutral-light-color);
   border-top: none;
   background: var(--app-form-color);


### PR DESCRIPTION
Updated simple-table-manual, dropdown and fieldvaluelist components for US-691679.

- When simple table manual is used in read only mode, displaying identifier value of dropdown instead of display value which we get from reference list. To fix this instead of showing string value, rendering component in displaymode DISPLAY_ONLY'.
- Updated dropdown component to filter options list and provided display value for respective identifier value.
- Fixed the styling of SimpleTableManual. Added min column width, as we are lossing information. Changed the way No records info is shown.
- Updated styling of FieldsValueList when there is no left label and only value is present for displaymode DISPLAY_ONLY'.