### PR TITLE
fix: Prevents the finish assignment screen from appearing

### DIFF
--- a/packages/angular-sdk-components/src/lib/_components/infra/Containers/flow-container/flow-container.component.ts
+++ b/packages/angular-sdk-components/src/lib/_components/infra/Containers/flow-container/flow-container.component.ts
@@ -6,7 +6,7 @@ import { publicConstants } from '@pega/pcore-pconnect-typedefs/constants';
 import { ProgressSpinnerService } from '../../../../_messages/progress-spinner.service';
 import { ReferenceComponent } from '../../reference/reference.component';
 import { Utils } from '../../../../_helpers/utils';
-import { getToDoAssignments, showBanner } from './helpers';
+import { getToDoAssignments, hasAssignments, showBanner } from './helpers';
 import { ComponentMapperComponent } from '../../../../_bridge/component-mapper/component-mapper.component';
 import { FlowContainerBaseComponent } from '../base-components/flow-container-base.component';
 
@@ -277,41 +277,6 @@ export class FlowContainerComponent extends FlowContainerBaseComponent implement
     this.psService.sendMessage(false);
   }
 
-  hasAssignments() {
-    let hasAssignments = false;
-    const assignmentsList = this.pConn$.getValue(this.pCoreConstants.CASE_INFO.D_CASE_ASSIGNMENTS_RESULTS);
-    // const thisOperator = PCore.getEnvironmentInfo().getOperatorIdentifier();
-    // 8.7 includes assignments in Assignments List that may be assigned to
-    //  a different operator. So, see if there are any assignments for
-    //  the current operator
-    const isEmbedded = window.location.href.includes('embedded');
-    let bAssignmentsForThisOperator = false;
-
-    if (isEmbedded) {
-      const thisOperator = PCore.getEnvironmentInfo().getOperatorIdentifier();
-      for (const assignment of assignmentsList) {
-        if (assignment.assigneeInfo.ID === thisOperator) {
-          bAssignmentsForThisOperator = true;
-        }
-      }
-    } else {
-      bAssignmentsForThisOperator = true;
-    }
-
-    // Bail if there is no assignmentsList
-    if (!assignmentsList) {
-      return hasAssignments;
-    }
-
-    const hasChildCaseAssignments = this.hasChildCaseAssignments();
-
-    if (bAssignmentsForThisOperator || hasChildCaseAssignments || this.isCaseWideLocalAction()) {
-      hasAssignments = true;
-    }
-
-    return hasAssignments;
-  }
-
   isCaseWideLocalAction() {
     const actionID = this.pConn$.getValue(this.pCoreConstants.CASE_INFO.ACTIVE_ACTION_ID);
     const caseActions = this.pConn$.getValue(this.pCoreConstants.CASE_INFO.AVAILABLEACTIONS);
@@ -461,7 +426,7 @@ export class FlowContainerComponent extends FlowContainerBaseComponent implement
     this.caseMessages$ = this.localizedVal(this.pConn$.getValue('caseMessages'), this.localeCategory);
     // caseMessages's behavior has changed in 24.2, and hence it doesn't let Optional Action work.
     // Changing the below condition for now. Was: (theCaseMessages || !hasAssignments())
-    if (!this.hasAssignments()) {
+    if (!hasAssignments(this.pConn$)) {
       this.bHasCaseMessages$ = true;
       this.bShowConfirm = true;
       this.checkSvg$ = this.utils.getImageSrc('check', this.utils.getSDKStaticContentUrl());
@@ -470,9 +435,6 @@ export class FlowContainerComponent extends FlowContainerBaseComponent implement
       if (!this.caseMessages$) {
         this.caseMessages$ = this.localizedVal('Thank you! The next step in this case has been routed appropriately.', this.localeCategory);
       }
-
-      // publish this "assignmentFinished" for mashup, need to get approved as a standard
-      PCore.getPubSubUtils().publish('assignmentFinished');
 
       this.psService.sendMessage(false);
     } else {

--- a/packages/angular-sdk-components/src/lib/_components/infra/Containers/flow-container/helpers.ts
+++ b/packages/angular-sdk-components/src/lib/_components/infra/Containers/flow-container/helpers.ts
@@ -28,7 +28,7 @@ function getChildCaseAssignments(pConnect) {
   return allAssignments;
 }
 
-function hasAssignments(pConnect) {
+export function hasAssignments(pConnect) {
   const { CASE_INFO } = PCore.getConstants();
   const assignments = pConnect.getValue(CASE_INFO.D_CASE_ASSIGNMENTS_RESULTS);
   const childCasesAssignments = getChildCaseAssignments(pConnect);

--- a/packages/angular-sdk-components/src/lib/_components/widget/todo/todo.component.html
+++ b/packages/angular-sdk-components/src/lib/_components/widget/todo/todo.component.html
@@ -1,10 +1,9 @@
 <div class="psdk-todo">
-  <div class="psdk-todo-header">
-    <div *ngIf="showTodoList$" class="psdk-avatar">{{ this.currentUserInitials$ }}</div>
+  <div *ngIf="showTodoList$" class="psdk-todo-header">
+    <div class="psdk-avatar">{{ this.currentUserInitials$ }}</div>
     <div id="worklist" class="psdk-todo-text">{{ headerText$ }}</div>
-    <div *ngIf="showTodoList$" class="psdk-assignment-count">{{ count }}</div>
+    <div class="psdk-assignment-count">{{ count }}</div>
   </div>
-  <br /><br />
   <div *ngIf="showTodoList$" class="psdk-display-divider"></div>
 
   <div class="psdk-todo-assignments">
@@ -27,7 +26,7 @@
             </div>
           </div>
         </div>
-        <div class="psdk-todo-assignment-action" *ngIf="!isConfirm || canPerform">
+        <div *ngIf="!isConfirm || canPerform" class="psdk-todo-assignment-action">
           <button mat-flat-button color="primary" (click)="clickGo(assignment)">{{ localizedVal('Go', localeCategory) }}</button>
         </div>
       </div>

--- a/packages/angular-sdk-components/src/lib/_components/widget/todo/todo.component.scss
+++ b/packages/angular-sdk-components/src/lib/_components/widget/todo/todo.component.scss
@@ -1,5 +1,12 @@
+.psdk-todo-assignments > *:last-child {
+  .psdk-display-divider {
+    display: none;
+  }
+}
+
 .psdk-display-divider {
   border-bottom: 0.0625rem solid var(--app-neutral-light-color);
+  margin-block: 0.5rem;
 }
 
 .psdk-todo {
@@ -12,6 +19,7 @@
 
 .psdk-todo-header {
   display: inline-flex;
+  margin-bottom: 1rem;
 }
 
 .psdk-todo-text {

--- a/packages/angular-sdk-components/src/lib/_components/widget/todo/todo.component.ts
+++ b/packages/angular-sdk-components/src/lib/_components/widget/todo/todo.component.ts
@@ -91,7 +91,6 @@ export class TodoComponent implements OnInit, OnDestroy {
   localeCategory = 'Todo';
   showlessLocalizedValue = this.localizedVal('show_less', 'CosmosFields');
   showMoreLocalizedValue = this.localizedVal('show_more', 'CosmosFields');
-  canPerform: boolean;
   count: number;
 
   constructor(
@@ -117,6 +116,10 @@ export class TodoComponent implements OnInit, OnDestroy {
     PCore.getPubSubUtils().unsubscribe(PCore.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL, 'updateToDo');
     PCore.getPubSubUtils().unsubscribe(CREATE_STAGE_SAVED, CREATE_STAGE_SAVED);
     PCore.getPubSubUtils().unsubscribe(CREATE_STAGE_DELETED, CREATE_STAGE_DELETED);
+  }
+
+  get canPerform() {
+    return this.assignmentsSource$?.[0]?.canPerform === 'true' || this.assignmentsSource$?.[0]?.canPerform === true;
   }
 
   updateList() {
@@ -155,8 +158,6 @@ export class TodoComponent implements OnInit, OnDestroy {
         this.arAssignments$ = this.getCaseInfoAssignment(this.assignmentsSource$, this.caseInfoID$);
       }
     }
-
-    this.canPerform = this.arAssignments$?.[0]?.canPerform === 'true' || this.arAssignments$?.[0]?.canPerform === true;
 
     this.currentUser$ = PCore.getEnvironmentInfo().getOperatorName();
     this.currentUserInitials$ = this.utils.getInitials(this.currentUser$ ?? '');

--- a/projects/angular-test-app/src/app/_samples/embedded/main-screen/main-screen.component.ts
+++ b/projects/angular-test-app/src/app/_samples/embedded/main-screen/main-screen.component.ts
@@ -29,6 +29,7 @@ export class MainScreenComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    // Subscribe to the EVENT_CANCEL event to handle the assignment cancellation
     PCore.getPubSubUtils().subscribe(
       PCore.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL,
       () => {
@@ -37,19 +38,20 @@ export class MainScreenComponent implements OnInit, OnDestroy {
       'cancelAssignment'
     );
 
+    // Subscribe to the END_OF_ASSIGNMENT_PROCESSING event to handle assignment completion
     PCore.getPubSubUtils().subscribe(
-      'assignmentFinished',
+      PCore.getConstants().PUB_SUB_EVENTS.CASE_EVENTS.END_OF_ASSIGNMENT_PROCESSING,
       () => {
         this.assignmentFinished();
       },
-      'assignmentFinished'
+      'endOfAssignmentProcessing'
     );
   }
 
   ngOnDestroy() {
     PCore.getPubSubUtils().unsubscribe(PCore.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL, 'cancelAssignment');
 
-    PCore.getPubSubUtils().unsubscribe('assignmentFinished', 'assignmentFinished');
+    PCore.getPubSubUtils().unsubscribe(PCore.getConstants().PUB_SUB_EVENTS.CASE_EVENTS.END_OF_ASSIGNMENT_PROCESSING, 'endOfAssignmentProcessing');
   }
 
   cancelAssignment() {

--- a/projects/angular-test-app/src/containerStyles.scss
+++ b/projects/angular-test-app/src/containerStyles.scss
@@ -14,7 +14,7 @@ app-flow-container {
 
   .psdk-flow-container-top {
     background-color: var(--app-form-color);
-    padding: 0rem 0.625rem;
+    padding: 0.5rem 0.625rem;
     border-radius: 0.3125rem;
   }
   .psdk-flow-container {


### PR DESCRIPTION
- Prevents the finish assignment screen from appearing when opening an assignment assigned to a different operator
- refactor: event subscription for assignment completion handling