### PR TITLE
#512: by moving the value mapping to the end, this.options$ is always populated before trying to match the key

### DIFF
--- a/packages/angular-sdk-components/src/lib/_components/field/auto-complete/auto-complete.component.ts
+++ b/packages/angular-sdk-components/src/lib/_components/field/auto-complete/auto-complete.component.ts
@@ -94,12 +94,6 @@ export class AutoCompleteComponent extends FieldBase implements OnInit {
     // Set component specific properties
     const { value, listType, parameters } = this.configProps$;
 
-    if (value != undefined) {
-      const index = this.options$?.findIndex(element => element.key === value);
-      this.value$ = index > -1 ? this.options$[index].value : value;
-      this.fieldControl.setValue(this.value$);
-    }
-
     this.listType = listType;
     this.parameters = parameters;
 
@@ -118,6 +112,12 @@ export class AutoCompleteComponent extends FieldBase implements OnInit {
     if (!this.displayMode$ && this.listType !== 'associated') {
       const results = await this.dataPageService.getDataPageData(datasource, this.parameters, context);
       this.fillOptions(results);
+    }
+
+    if (value != undefined) {
+      const index = this.options$?.findIndex(element => element.key === value);
+      this.value$ = index > -1 ? this.options$[index].value : value;
+      this.fieldControl.setValue(this.value$);
     }
   }
 

--- a/packages/angular-sdk-components/src/lib/_helpers/template-utils.ts
+++ b/packages/angular-sdk-components/src/lib/_helpers/template-utils.ts
@@ -53,7 +53,7 @@ export class TemplateUtils {
     // it is evaluated by core logic to the content
     if (instructions !== 'casestep' && instructions !== 'none') {
       // if the instructions contains a link, and the link is external, add a target attribute to open in a new window
-      if (instructions.includes('<a')) {
+      if (instructions?.includes('<a')) {
         const parser = new DOMParser();
         const htmlDoc = parser.parseFromString(instructions, 'text/html');
         const anchorNode = htmlDoc.querySelector('a');


### PR DESCRIPTION
Issue description in #512 